### PR TITLE
fix couple of '@return:' into '@return ' (jdk 11 complains)

### DIFF
--- a/src/main/java/io/bdrc/lucene/sa/CmdParser.java
+++ b/src/main/java/io/bdrc/lucene/sa/CmdParser.java
@@ -130,7 +130,7 @@ public class CmdParser {
 	 * 
 	 * @param inflected  the inflected form (a substring of the input string)
 	 * @param cmd to be parsed. contains the info for reconstructing lemmas 
-	 * @return: parsed structure 
+	 * @return parsed structure 
 	 */
 
 	public TreeMap<String, TreeSet<DiffStruct>> parse(String inflected, String cmd) {

--- a/src/main/java/io/bdrc/lucene/sa/SkrtWordTokenizer.java
+++ b/src/main/java/io/bdrc/lucene/sa/SkrtWordTokenizer.java
@@ -1100,7 +1100,7 @@ public final class SkrtWordTokenizer extends Tokenizer {
 	 * @param inflected the inflected word to be lemmatized
 	 * @param tokenEndIdx 
 	 *
-	 * @return: the list of all the possible lemmas given the current context
+	 * @return the list of all the possible lemmas given the current context
 	 */
 	TreeSet<String> reconstructLemmas(String cmd, String inflected, int tokenEndIdx) throws NumberFormatException, IOException {
 		TreeSet<String> totalLemmas = new TreeSet<String>();	// uses a Set to avoid duplicates
@@ -1176,7 +1176,7 @@ public final class SkrtWordTokenizer extends Tokenizer {
 	 * See SandhiedCombinationTests for how these figures were obtained
 	 *
 	 * @param ioBuffer: is given as parameter for the tests
-	 * @return: true if sandhied is one of the combinations; false otherwise
+	 * @return true if sandhied is one of the combinations; false otherwise
 	 */
 	static boolean containsSandhiedCombination(RollingCharBuffer ioBuffer, int bufferIndex, String sandhied, int sandhiType) throws IOException {
 		switch(sandhiType) {


### PR DESCRIPTION
Rather cosmetic change, but needed to fix the documentation build in openJDK11