### PR TITLE
Stj ctor refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ A text in IAST is tokenized in words for indexing. The queries are in SLP and to
 
 ##### 2. Lenient search (words)
 A text in IAST is tokenized in words. The queries in IAST are tokenized at spaces: search users provide separate words with no sandhi applied. Geminates are normalized(`true`) only at indexing time so that geminates are considered to be spelling variants instead of mistakes. The lenient search is enabled by indicating either "index" or "query", thereby selecting the appropriate pipeline of filters.
-- Indexing:  `SanskritAnalyzer("word", "roman", false, true, "index")`
-- Querying:  `SanskritAnalyzer("space", "roman", false, false, "query")`
+- Indexing:  `SanskritAnalyzer("word", "roman", false, true, "index")` or simpler: `SanskritAnalyzer.IndexLenientWord()`
+- Querying:  `SanskritAnalyzer("space", "roman", false, false, "query")` or simpler: `SanskritAnalyzer.QueryLenientWord()`
 
 ##### 3. Lenient search (syllables)
 The encoding of the text to index and that of the query is the same as above. Lenient search is also enabled in the same way.
-- Indexing:  `SanskritAnalyzer("syl", "roman", false, true, "index")`
-- Querying:  `SanskritAnalyzer("syl", "roman", false, false, "query")`
+- Indexing:  `SanskritAnalyzer("syl", "roman", false, true, "index")` or simpler: `SanskritAnalyzer.IndexLenientSyl()`
+- Querying:  `SanskritAnalyzer("syl", "roman", false, false, "query")` or simpler: `SanskritAnalyzer.QueryLenientSyl()`
 
 ### SkrtWordTokenizer
 

--- a/src/main/java/io/bdrc/lucene/sa/SanskritAnalyzer.java
+++ b/src/main/java/io/bdrc/lucene/sa/SanskritAnalyzer.java
@@ -238,26 +238,26 @@ public class SanskritAnalyzer extends Analyzer {
 	}
 
     public class IndexLenientSyl extends SanskritAnalyzer {
-        public IndexLenientSyl(String inputEncoding) throws IOException {
-            super("syl", inputEncoding, false, true, "index");
+        public IndexLenientSyl() throws IOException {
+            super("syl", "roman", false, true, "index");
         }
     }
 
     public class QueryLenientSyl extends SanskritAnalyzer {
-        public QueryLenientSyl(String inputEncoding) throws IOException {
-            super("syl", inputEncoding, false, false, "query");
+        public QueryLenientSyl() throws IOException {
+            super("syl", "roman", false, false, "query");
         }
     }
 
     public class IndexLenientWord extends SanskritAnalyzer {
-        public IndexLenientWord(String inputEncoding) throws IOException {
-            super("word", inputEncoding, false, true, "index");
+        public IndexLenientWord() throws IOException {
+            super("word", "roman", false, true, "index");
         }
     }
 
     public class QueryLenientWord extends SanskritAnalyzer {
-        public QueryLenientWord(String inputEncoding) throws IOException {
-            super("word", inputEncoding, false, false, "query");
+        public QueryLenientWord() throws IOException {
+            super("space", "roman", false, false, "query");
         }
     }
 }

--- a/src/main/java/io/bdrc/lucene/sa/SanskritAnalyzer.java
+++ b/src/main/java/io/bdrc/lucene/sa/SanskritAnalyzer.java
@@ -84,6 +84,7 @@ public class SanskritAnalyzer extends Analyzer {
 	public SanskritAnalyzer(String mode, String inputEncoding) throws IOException {
         // Turn stopwords filter OFF for "syl" mode:
         this(mode, inputEncoding, "syl".equals(mode) ? null : defaultStopFile);
+        if ("syl".equals(mode)) CommonHelpers.logger.info("StopWords filter turned off due to 'syl' mode");
 	}
 	
 	/**
@@ -114,7 +115,7 @@ public class SanskritAnalyzer extends Analyzer {
 	    if ("word".equals(mode)) {
 	        this.mergePrepositions = mergePrepositions;
 	    } else if (mergePrepositions){
-	        CommonHelpers.logger.error("Can only merge prepositions if mode == word");
+	        CommonHelpers.logger.error("Can only merge prepositions in 'word' mode");
 	        return;
 	    }
 	}
@@ -215,7 +216,7 @@ public class SanskritAnalyzer extends Analyzer {
 		} else if ("space".equals(mode)) {
 		    source = new WhitespaceTokenizer();
 		} else {
-		    throw new IllegalArgumentException("Illegal argument 'mode' value: " + mode);
+		    throw new IllegalArgumentException("Illegal argument `mode` value: " + mode);
 		}
 		
 		if (skrtStopWords != null) {  // a stop list was parsed


### PR DESCRIPTION
There are mostly 3 things here:

1. Got rid of the magical convention _'pass empty string for stopFilename if you want the default one'_ (passing empty string will still work for backward compatibility)
1. stopwords filter is turned OFF for "syl" mode (as suggested by Élie)
1. added 4 additional (inner static) subclasses of Sanskrit Analyzer, aiming to greatly simplify the c-tor invocations for various cases of Lenient mode ('word' vs 'syl') x (Index vs Query) 
